### PR TITLE
Adds aws provider version constraint to versions older than 5.0.0 whe…

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.64.0, != 4.0.0, != 4.1.0, != 4.2.0, != 4.3.0, != 4.4.0, != 4.5.0, != 4.6.0, != 4.7.0, != 4.8.0"
+      version = ">= 3.64.0, != 4.0.0, != 4.1.0, != 4.2.0, != 4.3.0, != 4.4.0, != 4.5.0, != 4.6.0, != 4.7.0, != 4.8.0, < 5.0.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION


## what

Adds version constraint for AWS provider, since this parameter is not supported since 5.0.0

## why

Using AWS provider 5.0.0 or higher gives an error

## references

- https://registry.terraform.io/providers/hashicorp/aws/5.0.0/docs/data-sources/iam_policy_document
