### PR TITLE
5f67884 oac

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,11 @@ locals {
   s3_access_logging_enabled = local.enabled && (var.s3_access_logging_enabled == null ? length(var.s3_access_log_bucket_name) > 0 : var.s3_access_logging_enabled)
   create_cf_log_bucket      = local.cloudfront_access_logging_enabled && local.cloudfront_access_log_create_bucket
 
-  create_cloudfront_origin_access_identity = local.enabled && length(compact([var.cloudfront_origin_access_identity_iam_arn])) == 0 # "" or null
+  #create_cloudfront_origin_access_identity = local.enabled && length(compact([var.cloudfront_origin_access_identity_iam_arn])) == 0 # "" or null
+  origin_access_control_enabled            = local.enabled && var.origin_access_type == "origin_access_control"
+  create_cloudfront_origin_access_control  = local.origin_access_control_enabled && length(compact([var.cloudfront_origin_access_control_id])) == 0
+  create_cloudfront_origin_access_identity = local.enabled && var.origin_access_type == "origin_access_identity" && length(compact([var.cloudfront_origin_access_identity_iam_arn])) == 0
+
 
   origin_id   = module.this.id != "" ? module.this.id : substr(md5("MOCKEDID${join("",var.aliases)}"),0,7)
   origin_path = coalesce(var.origin_path, "/")
@@ -30,7 +34,7 @@ locals {
   origin_bucket = local.origin_bucket_options[local.enabled ? (local.create_s3_origin_bucket ? "new" : "existing") : "disabled"]
 
   # Collect the information for cloudfront_origin_access_identity_iam and shorten the variable names
-  cf_access_options = {
+ cf_access_options = var.origin_access_type == "origin_access_identity" ? {
     new = local.create_cloudfront_origin_access_identity ? {
       arn  = aws_cloudfront_origin_access_identity.default[0].iam_arn
       path = aws_cloudfront_origin_access_identity.default[0].cloudfront_access_identity_path
@@ -39,8 +43,22 @@ locals {
       arn  = var.cloudfront_origin_access_identity_iam_arn
       path = var.cloudfront_origin_access_identity_path
     }
+  } : {
+    new = local.create_cloudfront_origin_access_control ? {
+      arn  = "arn:${join("", data.aws_partition.current[*].partition)}:cloudfront::${data.aws_caller_identity.current[0].account_id}:distribution/${aws_cloudfront_origin_access_control.default[0].id}"
+      path = ""
+    } : null
+    existing = {
+      arn  = var.cloudfront_origin_access_control_id != "" ? "arn:${join("", data.aws_partition.current[*].partition)}:cloudfront::${data.aws_caller_identity.current[0].account_id}:distribution/${var.cloudfront_origin_access_control_id}" : ""
+      path = ""
+    }
   }
-  cf_access = local.cf_access_options[local.create_cloudfront_origin_access_identity ? "new" : "existing"]
+  cf_access = local.cf_access_options[
+    var.origin_access_type == "origin_access_identity"
+      ? (local.create_cloudfront_origin_access_identity ? "new" : "existing")
+      : (local.create_cloudfront_origin_access_control ? "new" : "existing")
+  ]
+
 
   # Pick the IAM policy document based on whether the origin is an S3 origin or a Website origin
   iam_policy_document = local.enabled ? (
@@ -108,6 +126,10 @@ data "aws_region" "current" {
   count = local.enabled ? 1 : 0
 }
 
+data "aws_caller_identity" "current" {
+  count = local.enabled ? 1 : 0
+}
+
 module "origin_label" {
   source  = "cloudposse/label/null"
   version = "0.25.0"
@@ -135,27 +157,51 @@ data "aws_iam_policy_document" "s3_origin" {
 
   override_json = local.override_policy
 
-  statement {
-    sid = "S3GetObjectForCloudFront"
+  dynamic "statement" {
+    for_each = local.origin_access_control_enabled ? [1] : []
+    content {
+      sid     = "AllowCloudFrontServicePrincipal"
+      actions = ["s3:GetObject"]
+      resources = ["arn:${join("", data.aws_partition.current[*].partition)}:s3:::${local.bucket}${local.origin_path}*"]
 
-    actions   = ["s3:GetObject"]
-    resources = ["arn:${join("", data.aws_partition.current.*.partition)}:s3:::${local.bucket}${local.origin_path}*"]
+      principals {
+        type        = "Service"
+        identifiers = ["cloudfront.amazonaws.com"]
+      }
 
-    principals {
-      type        = "AWS"
-      identifiers = [local.cf_access.arn]
+      condition {
+        test     = "ArnLike"
+        variable = "AWS:SourceArn"
+        values   = ["arn:${join("", data.aws_partition.current[*].partition)}:cloudfront::${data.aws_caller_identity.current[0].account_id}:distribution/${aws_cloudfront_distribution.default[0].id}"]
+      }
     }
   }
 
-  statement {
-    sid = "S3ListBucketForCloudFront"
+  dynamic "statement" {
+    for_each = local.origin_access_control_enabled ? [] : [1]
+    content {
+      sid     = "S3GetObjectForCloudFront"
+      actions = ["s3:GetObject"]
+      resources = ["arn:${join("", data.aws_partition.current[*].partition)}:s3:::${local.bucket}${local.origin_path}*"]
 
-    actions   = ["s3:ListBucket"]
-    resources = ["arn:${join("", data.aws_partition.current.*.partition)}:s3:::${local.bucket}"]
+      principals {
+        type        = "AWS"
+        identifiers = [local.cf_access.arn]
+      }
+    }
+  }
 
-    principals {
-      type        = "AWS"
-      identifiers = [local.cf_access.arn]
+  dynamic "statement" {
+    for_each = local.origin_access_control_enabled ? [] : [1]
+    content {
+      sid     = "S3ListBucketForCloudFront"
+      actions = ["s3:ListBucket"]
+      resources = ["arn:${join("", data.aws_partition.current[*].partition)}:s3:::${local.bucket}"]
+
+      principals {
+        type        = "AWS"
+        identifiers = [local.cf_access.arn]
+      }
     }
   }
 }
@@ -417,12 +463,20 @@ resource "aws_cloudfront_distribution" "default" {
     origin_id   = local.origin_id
     origin_path = var.origin_path
 
-    dynamic "s3_origin_config" {
-      for_each = !var.website_enabled ? [1] : []
-      content {
-        origin_access_identity = local.cf_access.path
-      }
+    # OAC tiene precedencia si origin_access_type = origin_access_control
+    origin_access_control_id = local.origin_access_control_enabled ? (
+      local.create_cloudfront_origin_access_control
+      ? aws_cloudfront_origin_access_control.default[0].id
+      : var.cloudfront_origin_access_control_id
+  ) : null
+
+  dynamic "s3_origin_config" {
+    # Solo se usa OAI si NO estamos usando OAC
+    for_each = (!var.website_enabled && var.origin_access_type == "origin_access_identity") ? [1] : []
+    content {
+      origin_access_identity = local.cf_access.path
     }
+  }
 
     dynamic "custom_origin_config" {
       for_each = var.website_enabled ? [1] : []
@@ -476,17 +530,28 @@ resource "aws_cloudfront_distribution" "default" {
   }
 
   dynamic "origin" {
-    for_each = var.s3_origins
-    content {
-      domain_name = origin.value.domain_name
-      origin_id   = origin.value.origin_id
-      origin_path = lookup(origin.value, "origin_path", "")
-      s3_origin_config {
-        # the following enables specifying the origin_access_identity used by the origin created by this module, prior to the module's creation:
+  for_each = var.s3_origins
+  content {
+    domain_name = origin.value.domain_name
+    origin_id   = origin.value.origin_id
+    origin_path = lookup(origin.value, "origin_path", "")
+
+    # OAC a nivel de origen S3 adicional
+    origin_access_control_id = local.origin_access_control_enabled ? (
+      try(length(origin.value.origin_access_control_id), 0) > 0
+        ? origin.value.origin_access_control_id
+        : aws_cloudfront_origin_access_control.default[0].id
+    ) : null
+
+    dynamic "s3_origin_config" {
+      # Solo si estamos usando OAI
+      for_each = var.origin_access_type == "origin_access_identity" ? [1] : []
+      content {
         origin_access_identity = try(length(origin.value.s3_origin_config.origin_access_identity), 0) > 0 ? origin.value.s3_origin_config.origin_access_identity : local.cf_access.path
       }
     }
   }
+}
 
   viewer_certificate {
     acm_certificate_arn            = var.acm_certificate_arn
@@ -637,4 +702,14 @@ module "dns" {
   ipv6_enabled     = var.ipv6_enabled
 
   context = module.this.context
+}
+
+
+resource "aws_cloudfront_origin_access_control" "default" {
+  count                             = local.create_cloudfront_origin_access_control ? 1 : 0
+  name                              = local.origin_id
+  description                       = local.origin_id
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = var.origin_access_control_signing_behavior
+  signing_protocol                  = "sigv4"
 }

--- a/main.tf
+++ b/main.tf
@@ -155,7 +155,7 @@ resource "random_password" "referer" {
 data "aws_iam_policy_document" "s3_origin" {
   count = local.s3_origin_enabled ? 1 : 0
 
-  override_json = local.override_policy
+  override_policy_documents = local.override_policy != "" ? [local.override_policy] : []
 
   dynamic "statement" {
     for_each = local.origin_access_control_enabled ? [1] : []
@@ -209,7 +209,8 @@ data "aws_iam_policy_document" "s3_origin" {
 data "aws_iam_policy_document" "s3_website_origin" {
   count = local.website_enabled ? 1 : 0
 
-  override_json = local.override_policy
+  #override_json = local.override_policy
+  override_policy_documents = local.override_policy != "" ? [local.override_policy] : []
 
   statement {
     sid = "S3GetObjectForCloudFront"
@@ -302,7 +303,7 @@ resource "aws_s3_bucket" "origin" {
   count = local.create_s3_origin_bucket ? 1 : 0
 
   bucket        = module.origin_label.id
-  acl           = "private"
+  #acl           = "private"
   tags          = module.origin_label.tags
   force_destroy = var.origin_force_destroy
 
@@ -350,6 +351,14 @@ resource "aws_s3_bucket" "origin" {
       max_age_seconds = var.cors_max_age_seconds
     }
   }
+}
+
+resource "aws_s3_bucket_acl" "origin" {
+  count  = local.create_s3_origin_bucket ? 1 : 0
+  bucket = aws_s3_bucket.origin[0].id
+  acl    = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.origin]
 }
 
 resource "aws_s3_bucket_public_access_block" "origin" {

--- a/variables.tf
+++ b/variables.tf
@@ -450,12 +450,13 @@ variable "custom_origins" {
 
 variable "s3_origins" {
   type = list(object({
-    domain_name = string
-    origin_id   = string
-    origin_path = string
-    s3_origin_config = object({
-      origin_access_identity = string
-    })
+    domain_name    = string
+    origin_id      = string
+    origin_path    = optional(string, "")
+    origin_access_control_id = optional(string, "") # <-- agregar esto
+    s3_origin_config = optional(object({
+      origin_access_identity = optional(string, "")
+    }), { origin_access_identity = "" })
   }))
   default     = []
   description = <<-EOT
@@ -685,4 +686,26 @@ variable "enable_origin_bucket_creation" {
   type        = bool
   default     = true
   description = "Whether to enable the creation of a default s3 origin or not"
+}
+
+variable "origin_access_type" {
+  type        = string
+  default     = "origin_access_identity"
+  description = "Type of origin access. Valid values: `origin_access_identity`, `origin_access_control`."
+  validation {
+    condition     = contains(["origin_access_identity", "origin_access_control"], var.origin_access_type)
+    error_message = "Valid values are `origin_access_identity` or `origin_access_control`."
+  }
+}
+
+variable "cloudfront_origin_access_control_id" {
+  type        = string
+  default     = ""
+  description = "Existing CloudFront Origin Access Control ID. Used when `origin_access_type = origin_access_control` and you want to reuse an existing OAC instead of creating a new one."
+}
+
+variable "origin_access_control_signing_behavior" {
+  type        = string
+  default     = "always"
+  description = "Signing behavior for OAC. Valid values: `always`, `never`, `no-override`."
 }


### PR DESCRIPTION
## what
- Add support for OAC (Origin Access Control) as an alternative to OAI (Origin Access Identity) via new variable `origin_access_type`
- Add `aws_cloudfront_origin_access_control` resource, created automatically when `origin_access_type = "origin_access_control"` and no existing OAC ID is provided
- Add `cloudfront_origin_access_control_id` variable to allow reuse of an existing OAC (import use case)
- Update `data.aws_iam_policy_document.s3_origin` to generate OAC-style bucket policy (`cloudfront.amazonaws.com` principal + `ArnLike` condition) when using OAC
- Fix deprecated `override_json` → `override_policy_documents` in `data.aws_iam_policy_document.s3_origin`
- Fix deprecated `acl = "private"` inline in `aws_s3_bucket.origin` → extracted to separate `aws_s3_bucket_acl` resource

## why
- OAC is the current AWS-recommended mechanism to restrict S3 bucket access to CloudFront, replacing the legacy OAI
- Existing deployments using OAI are unaffected — `origin_access_type` defaults to `"origin_access_identity"` preserving backward compatibility
- `override_json` and inline `acl` are deprecated in recent versions of the AWS Terraform provider and generate warnings on every plan/apply
- Importing existing CloudFront distributions that use OAC required passing the OAC ID explicitly without triggering resource recreation

## references
- [AWS — Restricting access to an Amazon S3 origin](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html)
- [AWS Provider — `aws_cloudfront_origin_access_control`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control)
- [AWS Provider — `override_json` deprecation](https://github.com/hashicorp/terraform-provider-aws/issues/30655)